### PR TITLE
CODA Licence feature: Set feature number to 1.1.1.release

### DIFF
--- a/ac.soton.coda.licence/feature.xml
+++ b/ac.soton.coda.licence/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.coda.licence"
       label="%CODALicenceFeatureName"
-      version="1.1.1.qualifier"
+      version="1.1.1.release"
       provider-name="%CODALicenceFeatureVendor">
 
    <description>


### PR DESCRIPTION
- Use .release instead of .qualifier so auto-builds work