### PR TITLE
fix property properties that cause build errors 

### DIFF
--- a/ac.soton.coda.licence/build.properties
+++ b/ac.soton.coda.licence/build.properties
@@ -1,3 +1,14 @@
+###############################################################################
+# (c) Crown owned copyright (2017) (UK Ministry of Defence)
+#
+# All rights reserved. This program and the accompanying materials are 
+# made available under the terms of the Eclipse Public License v1.0 which
+# accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#      University of Southampton - Initial API and implementation
+###############################################################################
 bin.includes = feature.xml,\
                feature.properties,\
                license.html,\

--- a/ac.soton.coda.licence/feature.properties
+++ b/ac.soton.coda.licence/feature.properties
@@ -1,7 +1,13 @@
 ###############################################################################
-# Copyright (c) 2017 AWE
-# All rights reserved. 
-# This program is private property.
+# (c) Crown owned copyright (2017) (UK Ministry of Defence)
+#
+# All rights reserved. This program and the accompanying materials are 
+# made available under the terms of the Eclipse Public License v1.0 which
+# accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#      University of Southampton - Initial API and implementation
 ###############################################################################
 # feature.properties
 # contains externalized strings for feature.xml
@@ -20,12 +26,12 @@ CODALicenceUpdateSiteName=TBA
 
 # "description" property - description of the feature
 CODALicenceDescription=\
-This feature provides the shared license for CODA platform \
+This feature provides the shared license for CODA platform \n\
 -------------------------------------------------------------------\n\
 Release history:\n\
-- 1.1.1: Update CODA Software User Agreement (EPL-based).
+- 1.1.1: Update CODA Software User Agreement (EPL-based).\n\
 - 1.1.0: CODA Software User Agreement.\n\
-- 1.0.0: Initial version
+- 1.0.0: Initial version\n\
 
 # "copyright" property - copyright of the feature
 CODALicenceCopyright=(c) Crown owned copyright (2017) (UK Ministry of Defence).

--- a/ac.soton.coda.licence/feature.properties
+++ b/ac.soton.coda.licence/feature.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# (c) Crown owned copyright (2017) (UK Ministry of Defence)
+# (c) Crown owned copyright (2017-2018) (UK Ministry of Defence)
 #
 # All rights reserved. This program and the accompanying materials are 
 # made available under the terms of the Eclipse Public License v1.0 which
@@ -34,7 +34,7 @@ Release history:\n\
 - 1.0.0: Initial version\n\
 
 # "copyright" property - copyright of the feature
-CODALicenceCopyright=(c) Crown owned copyright (2017) (UK Ministry of Defence).
+CODALicenceCopyright=(c) Crown owned copyright (2017-2018) (UK Ministry of Defence).
 
 # "licenseURL" property - URL of the "Feature Licence"
 # do not translate value - just change to point to a locale-specific HTML page


### PR DESCRIPTION
missing \n\ in text of property causes builder to detect property conflicts
also fixed copyright headers