### PR TITLE
gold.oracle extension changed to gold_oracle

### DIFF
--- a/ac.soton.coda.doc/latex/component_diagrams/component_diagrams-legal.tex
+++ b/ac.soton.coda.doc/latex/component_diagrams/component_diagrams-legal.tex
@@ -18,14 +18,6 @@ Secretary of State, as represented by the Copyright Unit, Defence
 Intellectual Property Rights, Poplar 2 \#2214, MOD Abbey Wood South,
 Bristol BS34 8JH, UNITED KINGDOM.
 
-CODA is provided on the basis that the US Government will disclose to
-the UK Ministry of Defence (via AWE) any information, test results,
-modifications or further developments based on or derived from the
-disclosed information and will authorise the use of such information
-for UK Government purposes on the same terms (i.e. under the terms of
-the Creative Commons Attribution-NonCommercial- ShareAlike 4.0
-International License (CC BY NC SA 4.0)).
-
 For the avoidance of doubt, the Secretary of State of Defence for the
 United Kingdom of Great Britain and Northern Ireland does not provide
 any indemnity, and does not warrant the accuracy or completeness of
@@ -44,10 +36,6 @@ project is provided to you under the terms and conditions of one of
 the following licences.
 
 \begin{itemize}
-\item The \emph{Creative Commons Attribution-NonCommercial-ShareAlike 4.0
-    International License} (CC BY NC SA 4.0).  A copy of the \emph{CC BY NC SA
-    4.0} is available at \url{https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode}.
-
 \item \emph{Eclipse Public License Version 1.0} (EPL) (available at 
    \url{http://www.eclipse.org/legal/epl-v10.html})
 \end{itemize}
@@ -63,7 +51,6 @@ locations:
 
 \begin{itemize}
 \item Feature directories
-
 \item Shared-licence feature \texttt{ac.soton.coda.licence}
 \end{itemize}
 
@@ -81,7 +68,7 @@ terms and conditions) that govern your use of the associated
 Content in that directory.
 
 THE FEATURE LICENCES, AND FEATURE UPDATE LICENCES MAY REFER
-TO THE CC BY NC SA 4.0, EPL OR OTHER LICENCE AGREEMENTS, NOTICES OR TERMS AND
+TO THE EPL OR OTHER LICENCE AGREEMENTS, NOTICES OR TERMS AND
 CONDITIONS.
 
 IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND

--- a/ac.soton.coda.doc/latex/component_diagrams/component_diagrams-validationAndSimulation.tex
+++ b/ac.soton.coda.doc/latex/component_diagrams/component_diagrams-validationAndSimulation.tex
@@ -137,7 +137,7 @@ The gold and playback runs are saved into a folder, called Oracle in the project
 
 Gold runs:
 
-\texttt{<Machine name>.test.<timestamp>.gold.oracle}
+\texttt{<Machine name>.test.<timestamp>.gold_oracle}
 
 Playback runs:
 

--- a/ac.soton.coda.doc/latex/simulator2/simulator2-legal.tex
+++ b/ac.soton.coda.doc/latex/simulator2/simulator2-legal.tex
@@ -18,14 +18,6 @@ Secretary of State, as represented by the Copyright Unit, Defence
 Intellectual Property Rights, Poplar 2 \#2214, MOD Abbey Wood South,
 Bristol BS34 8JH, UNITED KINGDOM.
 
-CODA is provided on the basis that the US Government will disclose to
-the UK Ministry of Defence (via AWE) any information, test results,
-modifications or further developments based on or derived from the
-disclosed information and will authorise the use of such information
-for UK Government purposes on the same terms (i.e. under the terms of
-the Creative Commons Attribution-NonCommercial- ShareAlike 4.0
-International License (CC BY NC SA 4.0)).
-
 For the avoidance of doubt, the Secretary of State of Defence for the
 United Kingdom of Great Britain and Northern Ireland does not provide
 any indemnity, and does not warrant the accuracy or completeness of
@@ -37,17 +29,13 @@ in the first instance, be directed to AWE Commercial (via the Formal
 Methods team at AWE).
 
 \subsubsection{Applicable Licences}
-\label{sec:simulator2-applicable-licences}
+\label{sec:component_diagrams-applicable-licences}
 
 Unless otherwise indicated, all Content made available by the CODA
 project is provided to you under the terms and conditions of one of
 the following licences.
 
 \begin{itemize}
-\item The \emph{Creative Commons Attribution-NonCommercial-ShareAlike 4.0
-    International License} (CC BY NC SA 4.0).  A copy of the \emph{CC BY NC SA
-    4.0} is available at \url{https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode}.
-
 \item \emph{Eclipse Public License Version 1.0} (EPL) (available at 
    \url{http://www.eclipse.org/legal/epl-v10.html})
 \end{itemize}
@@ -63,7 +51,6 @@ locations:
 
 \begin{itemize}
 \item Feature directories
-
 \item Shared-licence feature \texttt{ac.soton.coda.licence}
 \end{itemize}
 
@@ -81,7 +68,7 @@ terms and conditions) that govern your use of the associated
 Content in that directory.
 
 THE FEATURE LICENCES, AND FEATURE UPDATE LICENCES MAY REFER
-TO THE CC BY NC SA 4.0, EPL OR OTHER LICENCE AGREEMENTS, NOTICES OR TERMS AND
+TO THE EPL OR OTHER LICENCE AGREEMENTS, NOTICES OR TERMS AND
 CONDITIONS.
 
 IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND

--- a/ac.soton.coda.licence/feature.properties
+++ b/ac.soton.coda.licence/feature.properties
@@ -52,16 +52,10 @@ Usage Of Content\n\
 All intellectual property rights existing in this information remain the \
 property of the Secretary of State for Defence of the United Kingdom of Great \
 Britain and Northern Ireland. The information may not be used or disclosed \
-otherwise that is provided for by the licence without the prior \
+otherwise than is provided for by the licence without the prior \
 written permission of the Secretary of State, as represented by the Copyright \
 Unit, Defence Intellectual Property Rights, Poplar 2 #2214, MOD Abbey Wood South, \
 Bristol BS34 8JH, UNITED KINGDOM.\n\
-\n\
-CODA is provided on the basis that the US Government will disclose to the UK \
-Ministry of Defence (via AWE) any information, test results, modifications or \
-further developments based on or derived from the disclosed information and will \
-authorise the use of such information for UK Government purposes on the same terms \
-(i.e. under the terms of the Eclipse Public License Version 1.0 (EPL)).\n\
 \n\
 For the avoidance of doubt, the Secretary of State of Defence for the United \
 Kingdom of Great Britain and Northern Ireland does not provide any indemnity, \

--- a/ac.soton.coda.licence/feature.xml
+++ b/ac.soton.coda.licence/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.coda.licence"
       label="%CODALicenceFeatureName"
-      version="1.1.1.release"
+      version="1.1.2.qualifier"
       provider-name="%CODALicenceFeatureVendor">
 
    <description>

--- a/ac.soton.coda.licence/licence.html
+++ b/ac.soton.coda.licence/licence.html
@@ -16,7 +16,7 @@
 All intellectual property rights existing in this information remain
 the property of the Secretary of State for Defence of the United
 Kingdom of Great Britain and Northern Ireland. The information may not
-be used or disclosed otherwise that is provided for by the
+be used or disclosed otherwise than is provided for by the
 licence without the prior written permission of the
 Secretary of State, as represented by the Copyright Unit, Defence
 Intellectual Property Rights, Poplar 2 #2214, MOD Abbey Wood South,


### PR DESCRIPTION
The licence still had the old text in some places - which was displayed during installation.
Also update the documentation for this and for the gold_oracle extension